### PR TITLE
Added Gem Bowl

### DIFF
--- a/src/main/java/com/bewitchment/client/core/ClientProxy.java
+++ b/src/main/java/com/bewitchment/client/core/ClientProxy.java
@@ -13,6 +13,7 @@ import com.bewitchment.client.handler.Keybinds;
 import com.bewitchment.client.handler.ModelHandler;
 import com.bewitchment.client.render.entity.renderer.*;
 import com.bewitchment.client.render.tile.TileRenderCauldron;
+import com.bewitchment.client.render.tile.TileRenderGemBowl;
 import com.bewitchment.common.Bewitchment;
 import com.bewitchment.common.block.ModBlocks;
 import com.bewitchment.common.block.magic.BlockWitchFire;
@@ -28,6 +29,7 @@ import com.bewitchment.common.item.ModItems;
 import com.bewitchment.common.item.magic.ItemSpellPage;
 import com.bewitchment.common.lib.LibGui;
 import com.bewitchment.common.tile.TileEntityCauldron;
+import com.bewitchment.common.tile.TileEntityGemBowl;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.color.BlockColors;
@@ -205,6 +207,7 @@ public class ClientProxy implements ISidedProxy {
 		MinecraftForge.EVENT_BUS.register(new RenderBatSwarm.PlayerHider());
 
 		ClientRegistry.bindTileEntitySpecialRenderer(TileEntityCauldron.class, new TileRenderCauldron());
+		ClientRegistry.bindTileEntitySpecialRenderer(TileEntityGemBowl.class, new TileRenderGemBowl());
 	}
 
 	@Override

--- a/src/main/java/com/bewitchment/client/render/tile/TileRenderGemBowl.java
+++ b/src/main/java/com/bewitchment/client/render/tile/TileRenderGemBowl.java
@@ -1,0 +1,40 @@
+package com.bewitchment.client.render.tile;
+
+import com.bewitchment.common.tile.TileEntityGemBowl;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.block.model.IBakedModel;
+import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
+import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.client.ForgeHooksClient;
+import org.lwjgl.opengl.GL11;
+
+public class TileRenderGemBowl extends TileEntitySpecialRenderer<TileEntityGemBowl> {
+    @Override
+    public void render(TileEntityGemBowl te, double x, double y, double z, float partialTicks, int destroyStage, float alpha) {
+        if (te.hasGem()) {
+            ItemStack stack = te.getGem();
+            GlStateManager.enableRescaleNormal();
+            GlStateManager.alphaFunc(GL11.GL_GREATER, 0.1f);
+            GlStateManager.enableBlend();
+            RenderHelper.enableStandardItemLighting();
+            GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
+            GlStateManager.pushMatrix();
+            GlStateManager.translate(x + 0.5, y + 0.25, z + 0.5);
+            GlStateManager.rotate(90, 0,1,0);
+
+            IBakedModel model = Minecraft.getMinecraft().getRenderItem().getItemModelWithOverrides(stack, te.getWorld(), null);
+            model = ForgeHooksClient.handleCameraTransforms(model, ItemCameraTransforms.TransformType.GROUND, false);
+
+            Minecraft.getMinecraft().getTextureManager().bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
+            Minecraft.getMinecraft().getRenderItem().renderItem(stack, model);
+
+            GlStateManager.popMatrix();
+            GlStateManager.disableRescaleNormal();
+            GlStateManager.disableBlend();
+        }
+    }
+}

--- a/src/main/java/com/bewitchment/common/block/ModBlocks.java
+++ b/src/main/java/com/bewitchment/common/block/ModBlocks.java
@@ -6,6 +6,7 @@ import com.bewitchment.common.block.magic.BlockWitchFire;
 import com.bewitchment.common.block.magic.plants.BlockEmberGrass;
 import com.bewitchment.common.block.magic.plants.BlockRagingGrass;
 import com.bewitchment.common.block.magic.plants.BlockTorchwood;
+import com.bewitchment.common.block.misc.BlockGemBowl;
 import com.bewitchment.common.block.misc.BlockGoblet;
 import com.bewitchment.common.block.misc.BlockLantern;
 import com.bewitchment.common.block.misc.BlockWillOWisp;
@@ -119,6 +120,7 @@ public final class ModBlocks {
 	public static final Block scorned_bricks = null;
 	public static final Block scorned_brick_fence = null;
 	public static final Block goblet = null;
+	public static final Block gem_bowl = null;
 	public static final Block tarot_table = null;
 	public static final Block cold_iron_block = null;
 
@@ -195,6 +197,7 @@ public final class ModBlocks {
 				new BlockCircleGlyph(LibBlockName.GLYPHS),
 				new BlockCrystalBall(LibBlockName.CRYSTAL_BALL),
 				new BlockGoblet(LibBlockName.GOBLET),
+				new BlockGemBowl(LibBlockName.GEM_BOWL),
 				new BlockTarotTable(),
 				new BlockLantern(true),
 				new BlockLantern(false),

--- a/src/main/java/com/bewitchment/common/block/misc/BlockGemBowl.java
+++ b/src/main/java/com/bewitchment/common/block/misc/BlockGemBowl.java
@@ -1,0 +1,97 @@
+package com.bewitchment.common.block.misc;
+
+import com.bewitchment.common.block.BlockMod;
+import com.bewitchment.common.block.ModBlocks;
+import com.bewitchment.common.tile.TileEntityGemBowl;
+import net.minecraft.block.ITileEntityProvider;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+
+public class BlockGemBowl extends BlockMod implements ITileEntityProvider {
+    private static final AxisAlignedBB BOUNDING_BOX = new AxisAlignedBB(0.25f, 0.0f, 0.25f, 0.75f, 0.1875f, 0.75f);
+
+    public BlockGemBowl(String id) {
+        super(id, Material.ROCK);
+        this.setHarvestLevel("pickaxe", 0);
+        this.setLightOpacity(0);
+    }
+
+    @Override
+    public boolean canPlaceTorchOnTop(IBlockState state, IBlockAccess world, BlockPos pos) {
+        return false;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public boolean isFullBlock(IBlockState state) {
+        return false;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public boolean isBlockNormalCube(IBlockState state) {
+        return false;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public boolean isFullCube(IBlockState state) {
+        return false;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public boolean isOpaqueCube(IBlockState state) {
+        return false;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public boolean canProvidePower(IBlockState state) { return true; }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
+        return BOUNDING_BOX;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public boolean hasTileEntity() { return true; }
+
+    @Override
+    public TileEntity createNewTileEntity(World worldIn, int meta) {
+        return new TileEntityGemBowl();
+    }
+
+    @Override
+    public boolean onBlockActivated(World worldIn, BlockPos pos, IBlockState state, EntityPlayer playerIn, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) {
+        if(playerIn.isSneaking()) { return false; }
+        TileEntityGemBowl tile = (TileEntityGemBowl) worldIn.getTileEntity(pos);
+        tile.onBowlRightClicked(worldIn, pos, state, playerIn, hand, facing, hitX, hitY, hitZ);
+        return true;
+    }
+
+    @Override
+    public void breakBlock(World worldIn, BlockPos pos, IBlockState state) {
+        final TileEntity tile = worldIn.getTileEntity(pos);
+        if (tile != null && tile instanceof TileEntityGemBowl) {
+            TileEntityGemBowl gemBowl = (TileEntityGemBowl) tile;
+            EntityItem drop = new EntityItem(worldIn, pos.getX(), pos.getY(), pos.getZ(), gemBowl.getGem());
+            worldIn.spawnEntity(drop);
+        }
+        worldIn.removeTileEntity(pos);
+        EntityItem drop = new EntityItem(worldIn, pos.getX(), pos.getY(), pos.getZ(), new ItemStack(ModBlocks.gem_bowl));
+        worldIn.spawnEntity(drop);
+    }
+}

--- a/src/main/java/com/bewitchment/common/item/ModItems.java
+++ b/src/main/java/com/bewitchment/common/item/ModItems.java
@@ -341,6 +341,7 @@ public final class ModItems {
 				itemBlock(ModBlocks.infested_farmland),
 				itemBlock(ModBlocks.crystal_ball),
 				itemBlock(ModBlocks.goblet),
+				itemBlock(ModBlocks.gem_bowl),
 				itemBlock(ModBlocks.tarot_table),
 				itemBlock(ModBlocks.cold_iron_block),
 				new ItemBlockRevealingLantern(ModBlocks.lantern, false),

--- a/src/main/java/com/bewitchment/common/lib/LibBlockName.java
+++ b/src/main/java/com/bewitchment/common/lib/LibBlockName.java
@@ -95,6 +95,7 @@ public final class LibBlockName {
 	public static final String GLYPHS = "ritual_glyphs";
 	public static final String CRYSTAL_BALL = "crystal_ball";
 	public static final String GOBLET = "goblet";
+	public static final String GEM_BOWL = "gem_bowl";
 	public static final String TAROT_TABLE = "tarot_table";
 	public static final String WITCHFIRE = "witchfire";
 	public static final String LANTERN = "lantern";

--- a/src/main/java/com/bewitchment/common/tile/ModTiles.java
+++ b/src/main/java/com/bewitchment/common/tile/ModTiles.java
@@ -20,6 +20,7 @@ public final class ModTiles {
 	private static final ResourceLocation GLYPH = new ResourceLocation(LibMod.MOD_ID, "glyph");
 	private static final ResourceLocation CRYSTAL_BALL = new ResourceLocation(LibMod.MOD_ID, "crystal_ball");
 	private static final ResourceLocation TAROTS_TABLE = new ResourceLocation(LibMod.MOD_ID, "tarots_table");
+	private static final ResourceLocation GEM_BOWL = new ResourceLocation(LibMod.MOD_ID, "gem_bowl");
 
 	private ModTiles() {
 	}
@@ -35,5 +36,6 @@ public final class ModTiles {
 		GameRegistry.registerTileEntity(TileEntityGlyph.class, GLYPH);
 		GameRegistry.registerTileEntity(TileEntityCrystalBall.class, CRYSTAL_BALL);
 		GameRegistry.registerTileEntity(TileEntityTarotsTable.class, TAROTS_TABLE);
+		GameRegistry.registerTileEntity(TileEntityGemBowl.class, GEM_BOWL);
 	}
 }

--- a/src/main/java/com/bewitchment/common/tile/TileEntityGemBowl.java
+++ b/src/main/java/com/bewitchment/common/tile/TileEntityGemBowl.java
@@ -77,7 +77,7 @@ public class TileEntityGemBowl extends ModTileEntity {
     }
 
     public boolean hasGem() {
-        return gem.isEmpty();
+        return !gem.isEmpty();
     }
 
     public ItemStack getGem() {

--- a/src/main/java/com/bewitchment/common/tile/TileEntityGemBowl.java
+++ b/src/main/java/com/bewitchment/common/tile/TileEntityGemBowl.java
@@ -77,7 +77,7 @@ public class TileEntityGemBowl extends ModTileEntity {
     }
 
     public boolean hasGem() {
-        return gem != null;
+        return gem.isEmpty();
     }
 
     public ItemStack getGem() {

--- a/src/main/java/com/bewitchment/common/tile/TileEntityGemBowl.java
+++ b/src/main/java/com/bewitchment/common/tile/TileEntityGemBowl.java
@@ -1,0 +1,125 @@
+package com.bewitchment.common.tile;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.items.ItemHandlerHelper;
+import net.minecraftforge.oredict.OreDictionary;
+
+public class TileEntityGemBowl extends ModTileEntity {
+    private static final String[] ACCEPTED_ORE_NAMES = {"gemDiamond", "gemEmerald", "gemQuartz", "gemLapis",
+            "dustRedstone", "gemBloodstone", "gemMoldavite", "gemNuummite", "gemGarnet", "gemTourmaline",
+            "gemTigersEye", "gemJasper", "gemMalachite", "gemAmethyst", "gemAlexandrite"};
+    private ItemStack gem;
+
+    public TileEntityGemBowl() {
+        gem = new ItemStack(Items.AIR);
+    }
+
+    public void onBowlRightClicked(World worldIn, BlockPos pos, IBlockState state, EntityPlayer playerIn, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) {
+        if(!worldIn.isRemote) {
+            ItemStack held = playerIn.getHeldItem(hand);
+            if(held.isEmpty()) {
+                if(this.hasGem()) {
+                    playerIn.setHeldItem(hand, gem);
+                    gem = new ItemStack(Items.AIR);
+                    this.markDirty();
+                    this.syncToClient();
+                }
+            } else {
+                for(String acceptedName : ACCEPTED_ORE_NAMES) {
+                    for(int oreID : OreDictionary.getOreIDs(held)) {
+                        if(OreDictionary.getOreName(oreID).equals(acceptedName)) {
+                            ItemStack previousGem = gem;
+                            if(held.getCount() == 1) {
+                                gem = held;
+                                playerIn.setHeldItem(hand, previousGem);
+                            } else {
+                                gem = new ItemStack(held.getItem(), 1, held.getMetadata());
+                                held.setCount(held.getCount() - 1);
+                                if(!previousGem.isEmpty()) {
+                                    ItemHandlerHelper.giveItemToPlayer(playerIn, previousGem);
+                                }
+                            }
+                            this.markDirty();
+                            this.syncToClient();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    void readAllModDataNBT(NBTTagCompound cmp) {
+        gem = new ItemStack(cmp.getCompoundTag("gem"));
+    }
+
+    @Override
+    void writeAllModDataNBT(NBTTagCompound cmp) {
+        cmp.setTag("gem", gem.writeToNBT(new NBTTagCompound()));
+    }
+
+    @Override
+    void writeModSyncDataNBT(NBTTagCompound tag) {
+        tag.setTag("gem", gem.writeToNBT(new NBTTagCompound()));
+    }
+
+    @Override
+    void readModSyncDataNBT(NBTTagCompound tag) {
+        gem = new ItemStack(tag.getCompoundTag("gem"));
+    }
+
+    public boolean hasGem() {
+        return gem != null;
+    }
+
+    public ItemStack getGem() {
+        return gem;
+    }
+
+    public int getGain() {
+        if(gem.isEmpty()) { return 0; }
+        for(int oreID : OreDictionary.getOreIDs(gem)) {
+            String oreName = OreDictionary.getOreName(oreID);
+            if (oreName.equals("gemDiamond")) {
+                return 325;
+            } else if (oreName.equals("gemEmerald")) {
+                return 275;
+            } else if (oreName.equals("gemMoldavite")) {
+                return 225;
+            } else if (oreName.equals("gemAlexandrite")) {
+                return 225;
+            } else if (oreName.equals("gemNuummite")) {
+                return 225;
+            } else if (oreName.equals("gemGarnet")) {
+                return 225;
+            } else if (oreName.equals("gemAmethyst")) {
+                return 225;
+            } else if (oreName.equals("gemTourmaline")) {
+                return 225;
+            } else if (oreName.equals("gemTigersEye")) {
+                return 225;
+            } else if (oreName.equals("gemMalachite")) {
+                return 225;
+            } else if (oreName.equals("gemBloodstone")) {
+                return 225;
+            } else if (oreName.equals("gemJasper")) {
+                return 225;
+            } else if (oreName.equals("gemLapis")) {
+                return 225;
+            } else if (oreName.equals("gemQuartz")) {
+                return 225;
+            } else if (oreName.equals("dustRedstone")) {
+                return 200;
+            }
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/bewitchment/common/tile/TileEntityWitchAltar.java
+++ b/src/main/java/com/bewitchment/common/tile/TileEntityWitchAltar.java
@@ -1,6 +1,7 @@
 package com.bewitchment.common.tile;
 
 import com.bewitchment.common.block.ModBlocks;
+import com.bewitchment.common.block.misc.BlockGemBowl;
 import com.bewitchment.common.block.misc.BlockGoblet;
 import com.bewitchment.common.block.tools.BlockCandle;
 import com.bewitchment.common.block.tools.BlockWitchAltar;
@@ -140,37 +141,8 @@ public class TileEntityWitchAltar extends ModTileEntity implements ITickable {
 					return 1;
 				}
 			}
-			//TODO: Change the way gems are stored on an altar. Use a ritual plate. Pick them up via the oredict, to increase mod support.
-		} else if (blockState.getBlock().equals(Blocks.DIAMOND_BLOCK)) {
-			return 325;
-		} else if (blockState.getBlock().equals(Blocks.EMERALD_BLOCK)) {
-			return 275;
-		} else if (blockState.getBlock().equals(ModBlocks.moldavite_block)) {
-			return 225;
-		} else if (blockState.getBlock().equals(ModBlocks.alexandrite_block)) {
-			return 225;
-		} else if (blockState.getBlock().equals(ModBlocks.nuummite_block)) {
-			return 225;
-		} else if (blockState.getBlock().equals(ModBlocks.garnet_block)) {
-			return 225;
-		} else if (blockState.getBlock().equals(ModBlocks.amethyst_block)) {
-			return 225;
-		} else if (blockState.getBlock().equals(ModBlocks.tourmaline_block)) {
-			return 225;
-		} else if (blockState.getBlock().equals(ModBlocks.tigers_eye_block)) {
-			return 225;
-		} else if (blockState.getBlock().equals(ModBlocks.malachite_block)) {
-			return 225;
-		} else if (blockState.getBlock().equals(ModBlocks.bloodstone_block)) {
-			return 225;
-		} else if (blockState.getBlock().equals(ModBlocks.jasper_block)) {
-			return 225;
-		} else if (blockState.getBlock().equals(Blocks.LAPIS_BLOCK)) {
-			return 225;
-		} else if (blockState.getBlock().equals(Blocks.QUARTZ_BLOCK)) {
-			return 225;
-		} else if (blockState.getBlock().equals(Blocks.REDSTONE_BLOCK)) {
-			return 200;
+		} else if(blockState.getBlock() instanceof BlockGemBowl) {
+			return ((TileEntityGemBowl) world.getTileEntity(pos)).getGain();
 		} else if (blockState.getBlock() instanceof BlockCandle) {
 			if (types[1]) return 0;
 			types[1] = true;

--- a/src/main/resources/assets/bewitchment/blockstates/gem_bowl.json
+++ b/src/main/resources/assets/bewitchment/blockstates/gem_bowl.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "normal": {
+      "model": "bewitchment:gem_bowl"
+    }
+  }
+}

--- a/src/main/resources/assets/bewitchment/lang/en_US.lang
+++ b/src/main/resources/assets/bewitchment/lang/en_US.lang
@@ -339,6 +339,7 @@ fluid.none=Empty
 
 
 tile.goblet.name=Goblet
+tile.gem_bowl.name=Gem Bowl
 tile.tarot_table.name=Divination Table
 tile.planks_juniper.name=Juniper Wood Planks
 tile.planks_elder.name=Elder Wood Planks

--- a/src/main/resources/assets/bewitchment/models/block/gem_bowl.json
+++ b/src/main/resources/assets/bewitchment/models/block/gem_bowl.json
@@ -1,0 +1,149 @@
+{
+	"__comment": "Designed by rustylocks79 with Cubik Studio - https://cubik.studio",
+	"textures": {
+		"particle": "blocks/stone",
+		"texture": "blocks/stone"
+	},
+	"elements": [ 	 
+		{
+			"__comment": "Box1",
+			"from": [ 6, 0, 6 ],
+			"to": [ 10, 1, 10 ],
+			"faces": {
+				"down": { "uv": [ 6, 6, 10, 10 ], "texture": "#texture" },
+				"up": { "uv": [ 6, 6, 10, 10 ], "texture": "#texture" },
+				"north": { "uv": [ 6, 15, 10, 16 ], "texture": "#texture" },
+				"south": { "uv": [ 6, 15, 10, 16 ], "texture": "#texture" },
+				"west": { "uv": [ 6, 15, 10, 16 ], "texture": "#texture" },
+				"east": { "uv": [ 6, 15, 10, 16 ], "texture": "#texture" }
+			}
+		},
+		{
+			"__comment": "Box2",
+			"from": [ 5, 1, 5 ],
+			"to": [ 6, 2, 11 ],
+			"faces": {
+				"down": { "uv": [ 5, 6, 6, 12 ], "texture": "#texture" },
+				"up": { "uv": [ 5, 4, 6, 10 ], "texture": "#texture" },
+				"north": { "uv": [ 10, 14, 11, 15 ], "texture": "#texture" },
+				"south": { "uv": [ 5, 14, 6, 15 ], "texture": "#texture" },
+				"west": { "uv": [ 4, 14, 10, 15 ], "texture": "#texture" },
+				"east": { "uv": [ 6, 14, 12, 15 ], "texture": "#texture" }
+			}
+		},
+		{
+			"__comment": "Box2",
+			"from": [ 10, 1, 5 ],
+			"to": [ 11, 2, 11 ],
+			"faces": {
+				"down": { "uv": [ 5, 6, 6, 12 ], "texture": "#texture" },
+				"up": { "uv": [ 5, 4, 6, 10 ], "texture": "#texture" },
+				"north": { "uv": [ 10, 14, 11, 15 ], "texture": "#texture" },
+				"south": { "uv": [ 5, 14, 6, 15 ], "texture": "#texture" },
+				"west": { "uv": [ 4, 14, 10, 15 ], "texture": "#texture" },
+				"east": { "uv": [ 6, 14, 12, 15 ], "texture": "#texture" }
+			}
+		},
+		{
+			"__comment": "Box4",
+			"from": [ 6, 1, 5 ],
+			"to": [ 10, 2, 6 ],
+			"faces": {
+				"down": { "uv": [ 6, 11, 10, 12 ], "texture": "#texture" },
+				"up": { "uv": [ 6, 4, 10, 5 ], "texture": "#texture" },
+				"north": { "uv": [ 6, 14, 10, 15 ], "texture": "#texture" },
+				"south": { "uv": [ 6, 14, 10, 15 ], "texture": "#texture" },
+				"west": { "uv": [ 4, 14, 5, 15 ], "texture": "#texture" },
+				"east": { "uv": [ 11, 14, 12, 15 ], "texture": "#texture" }
+			}
+		},
+		{
+			"__comment": "Box5",
+			"from": [ 6, 1, 10 ],
+			"to": [ 10, 2, 11 ],
+			"faces": {
+				"down": { "uv": [ 6, 6, 10, 7 ], "texture": "#texture" },
+				"up": { "uv": [ 6, 9, 10, 10 ], "texture": "#texture" },
+				"north": { "uv": [ 6, 14, 10, 15 ], "texture": "#texture" },
+				"south": { "uv": [ 6, 14, 10, 15 ], "texture": "#texture" },
+				"west": { "uv": [ 9, 14, 10, 15 ], "texture": "#texture" },
+				"east": { "uv": [ 6, 14, 7, 15 ], "texture": "#texture" }
+			}
+		},
+		{
+			"__comment": "Box6",
+			"from": [ 4, 2, 4 ],
+			"to": [ 5, 3, 12 ],
+			"faces": {
+				"down": { "uv": [ 4, 5, 5, 13 ], "texture": "#texture" },
+				"up": { "uv": [ 4, 3, 5, 11 ], "texture": "#texture" },
+				"north": { "uv": [ 11, 13, 12, 14 ], "texture": "#texture" },
+				"south": { "uv": [ 4, 13, 5, 14 ], "texture": "#texture" },
+				"west": { "uv": [ 3, 13, 11, 14 ], "texture": "#texture" },
+				"east": { "uv": [ 5, 13, 13, 14 ], "texture": "#texture" }
+			}
+		},
+		{
+			"__comment": "Box7",
+			"from": [ 11, 2, 4 ],
+			"to": [ 12, 3, 12 ],
+			"faces": {
+				"down": { "uv": [ 11, 5, 12, 13 ], "texture": "#texture" },
+				"up": { "uv": [ 11, 3, 12, 11 ], "texture": "#texture" },
+				"north": { "uv": [ 4, 13, 5, 14 ], "texture": "#texture" },
+				"south": { "uv": [ 11, 13, 12, 14 ], "texture": "#texture" },
+				"west": { "uv": [ 3, 13, 11, 14 ], "texture": "#texture" },
+				"east": { "uv": [ 5, 13, 13, 14 ], "texture": "#texture" }
+			}
+		},
+		{
+			"__comment": "Box4",
+			"from": [ 5, 2, 4 ],
+			"to": [ 11, 3, 5 ],
+			"faces": {
+				"down": { "uv": [ 6, 11, 10, 12 ], "texture": "#texture" },
+				"up": { "uv": [ 6, 4, 10, 5 ], "texture": "#texture" },
+				"north": { "uv": [ 6, 14, 10, 15 ], "texture": "#texture" },
+				"south": { "uv": [ 6, 14, 10, 15 ], "texture": "#texture" },
+				"west": { "uv": [ 4, 14, 5, 15 ], "texture": "#texture" },
+				"east": { "uv": [ 11, 14, 12, 15 ], "texture": "#texture" }
+			}
+		},
+		{
+			"__comment": "Box4",
+			"from": [ 5, 2, 11 ],
+			"to": [ 11, 3, 12 ],
+			"faces": {
+				"down": { "uv": [ 6, 11, 10, 12 ], "texture": "#texture" },
+				"up": { "uv": [ 6, 4, 10, 5 ], "texture": "#texture" },
+				"north": { "uv": [ 6, 14, 10, 15 ], "texture": "#texture" },
+				"south": { "uv": [ 6, 14, 10, 15 ], "texture": "#texture" },
+				"west": { "uv": [ 4, 14, 5, 15 ], "texture": "#texture" },
+				"east": { "uv": [ 11, 14, 12, 15 ], "texture": "#texture" }
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"translation":  [ 0, 8, 0 ]
+		},
+		"thirdperson_lefthand": {
+			"translation":  [ 0, 8, 0 ]
+		},
+		"firstperson_righthand": {
+			"rotation":  [ 0, 25, 0 ],
+			"translation":  [ 0, 8, 0 ]
+		},
+		"firstperson_lefthand": {
+			"rotation":  [ 0, 25, 0 ],
+			"translation":  [ 0, 8, 0 ]
+		},
+		"gui": {
+			"rotation":  [ 25, 45, 0 ],
+			"translation":  [ 0, 1, 0 ]
+		},
+		"ground": {
+			"translation":  [ 0, 4, 0 ]
+		}
+	}
+}

--- a/src/main/resources/assets/bewitchment/models/item/gem_bowl.json
+++ b/src/main/resources/assets/bewitchment/models/item/gem_bowl.json
@@ -1,0 +1,3 @@
+{
+  "parent": "bewitchment:block/gem_bowl"
+}


### PR DESCRIPTION
- Added a new Tile Entity Gem Bowl
- Right-clicking on the bowl with an accepted gem places it in the bowl. 
- Accepted gems can be added easily by modifying the ACCEPTED_ORE_NAMES constant at the top of TileEntityGemBowl
- Right-clicking on the bowl with an empty hand removes the current gem.
- Moved the Gain Amount for gems from TileEntityWitchAltar to TileEntityGemBowl
