### PR TITLE
Make gem ores drop gems instead of the ore block

### DIFF
--- a/src/main/java/com/bewitchment/common/block/natural/BlockGemOre.java
+++ b/src/main/java/com/bewitchment/common/block/natural/BlockGemOre.java
@@ -32,7 +32,6 @@ import static com.bewitchment.common.core.ModCreativeTabs.BLOCKS_CREATIVE_TAB;
  */
 public class BlockGemOre extends BlockMod {
 
-	//FIXME: Make me drop gems again, and fix my crooked meta
 	public static final PropertyEnum<Gem> GEM = PropertyEnum.create("gem", Gem.class);
 
 	public BlockGemOre() {

--- a/src/main/java/com/bewitchment/common/block/natural/BlockGemOre.java
+++ b/src/main/java/com/bewitchment/common/block/natural/BlockGemOre.java
@@ -2,18 +2,26 @@ package com.bewitchment.common.block.natural;
 
 import com.bewitchment.client.handler.ModelHandler;
 import com.bewitchment.common.block.BlockMod;
+import com.bewitchment.common.item.ModItems;
 import com.bewitchment.common.lib.LibBlockName;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.NonNullList;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
+
+import java.util.Random;
 
 import static com.bewitchment.common.core.ModCreativeTabs.BLOCKS_CREATIVE_TAB;
 
@@ -59,6 +67,27 @@ public class BlockGemOre extends BlockMod {
 		for (int i = 0; i < Gem.values().length; ++i) {
 			items.add(new ItemStack(this, 1, i));
 		}
+	}
+	@Override
+	public Item getItemDropped(IBlockState state, Random rand, int fortune) { return ModItems.gem; }
+
+	@Override
+	public int quantityDroppedWithBonus(int fortune, Random random) {
+		if (fortune > 0 && Item.getItemFromBlock(this) != this.getItemDropped((IBlockState)this.getBlockState().getValidStates().iterator().next(), random, fortune)) {
+			int i = random.nextInt(fortune + 2) - 1;
+			if (i < 0) {
+				i = 0;
+			}
+
+			return this.quantityDropped(random) * (i + 1);
+		} else {
+			return this.quantityDropped(random);
+		}
+	}
+	@Override
+	public int getExpDrop(IBlockState state, IBlockAccess world, BlockPos pos, int fortune) {
+		Random rand = world instanceof World ? ((World)world).rand : new Random();
+		return MathHelper.getInt(rand, 2, 5);
 	}
 
 	@Override


### PR DESCRIPTION
I've made the various gem ores drop the appropriate gem, as well as making it respect fortune and give xp.  I matched the xp drops to quartz.  I'm not entirely sure why the quantityDroppedWithBonus needs to be there because its literally identical the to function in the base BlockOre class, but it doesn't work without it.  