### PR TITLE
Make dependency modids lowercase

### DIFF
--- a/src/main/java/com/bewitchment/common/lib/LibMod.java
+++ b/src/main/java/com/bewitchment/common/lib/LibMod.java
@@ -17,7 +17,7 @@ public final class LibMod {
 	public static final String MOD_VER = "0.0.12";
 
 	//Dependency
-	public static final String DEPENDENCIES = "required-after:forge@[14.23.4.2755,];after:JEI@[4.9.1.168,];after:Waila@[1.8.24-B39_1.12,];required-after:baubles@[1.5.2,]";
+	public static final String DEPENDENCIES = "required-after:forge@[14.23.4.2755,];after:jei@[4.9.1.168,];after:waila@[1.8.24-B39_1.12,];required-after:baubles@[1.5.2,]";
 
 	//Client proxy location
 	public static final String PROXY_CLIENT = "com.bewitchment.client.core.ClientProxy";


### PR DESCRIPTION
The existing modid string causes errors because forge can't parse modids that aren't all lowercase.  `[20:45:19] [main/ERROR] [FML]: Unable to parse dependency for mod 'bewitchment' with dependency string 'after:JEI@[4.9.1.168,]'. The modId 'JEI' must be all lowercase.
[20:45:19] [main/ERROR] [FML]: Unable to parse dependency for mod 'bewitchment' with dependency string 'after:Waila@[1.8.24-B39_1.12,]'. The modId 'Waila' must be all lowercase.`

I've made the modid for both JEI and Waila lowercase and those errors no longer show up in the log.  