### PR TITLE
fix #44 (snakes suffocate on solid blocks)

### DIFF
--- a/src/main/java/com/bewitchment/common/entity/living/familiar/EntitySnake.java
+++ b/src/main/java/com/bewitchment/common/entity/living/familiar/EntitySnake.java
@@ -31,7 +31,6 @@ import net.minecraft.world.World;
  * Created by Joseph on 10/2/2018.
  */
 
-//Todo: Fix suffocation upon spawning
 public class EntitySnake extends EntityFamiliar {
 
 	private static final double maxHPWild = 8;
@@ -41,6 +40,7 @@ public class EntitySnake extends EntityFamiliar {
 
 	public EntitySnake(World worldIn) {
 		super(worldIn);
+		setSize(1F,.3F);
 	}
 
 	public static boolean isSnakeFodder(Entity entity) {


### PR DESCRIPTION
I added a call to setSize for the snake entity to fix the hitbox.  I'm unsure as to what exactly the problem with the previous hitbox was, but this fixes it.  I had at first thought that the hitbox was just below the snake, but that shouldn't have caused it to suffocate against the floor.  The function setSize only takes a height and width argument, so the hitbox has to have the same width/length.  I've attached a picture of the new hitbox below.  

![capture](https://user-images.githubusercontent.com/1759360/46717114-2ff4cd80-cc2c-11e8-8538-295180e66907.PNG)
