### PR TITLE
Fixes clipping on snakes, blindworms, and urans. Memory leak.

### DIFF
--- a/src/main/java/com/bewitchment/client/render/entity/model/ModelBlindworm.java
+++ b/src/main/java/com/bewitchment/client/render/entity/model/ModelBlindworm.java
@@ -118,7 +118,8 @@ public class ModelBlindworm extends ModelBase {
 			this.head.rotateAngleX = 0;
 			this.head.rotateAngleZ = 0;
 		} else {
-			this.neck01b.addBox(-2.3F, -1.49F, -6.0F, 2, 3, 8, MathHelper.sin(time));
+	    	// TODO: This is the cause of the clipping. Additionally, boxes probably shouldn't be added during render() ... may be a memory leak.
+			// this.neck01b.addBox(-2.3F, -1.49F, -6.0F, 2, 3, 8, MathHelper.sin(time));
 
 		}
 		this.neck01a.render(scale);

--- a/src/main/java/com/bewitchment/client/render/entity/model/ModelSnake.java
+++ b/src/main/java/com/bewitchment/client/render/entity/model/ModelSnake.java
@@ -179,8 +179,8 @@ public class ModelSnake extends ModelBase {
 				this.head.rotateAngleZ = 0;
 				snek.resetTimer();
 			} else {
-				this.neck01b.addBox(-2.3F, -1.49F, -6.0F, 2, 3, 8, MathHelper.sin(time));
-
+	    		// TODO: This is the cause of the clipping. Additionally, boxes probably shouldn't be added during render() ... may be a memory leak.
+				//this.neck01b.addBox(-2.3F, -1.49F, -6.0F, 2, 3, 8, MathHelper.sin(time));
 			}
 		}
 		this.neck01a.render(scale);

--- a/src/main/java/com/bewitchment/client/render/entity/model/ModelUran.java
+++ b/src/main/java/com/bewitchment/client/render/entity/model/ModelUran.java
@@ -382,7 +382,8 @@ public class ModelUran extends ModelBase {
 				this.head.rotateAngleZ = 0;
 				uran.resetTimer();
 			} else {
-				this.neck01b.addBox(-2.3F, -1.49F, -6.0F, 2, 3, 8, MathHelper.sin(time));
+	    		// TODO: This is the cause of the clipping. Additionally, boxes probably shouldn't be added during render() ... may be a memory leak.
+				// this.neck01b.addBox(-2.3F, -1.49F, -6.0F, 2, 3, 8, MathHelper.sin(time));
 
 			}
 		}


### PR DESCRIPTION
Probably don't add boxes in render(), unless you actually want to add 60 new boxes to the model per second (on a 60hz monitor). It's bad for your health... also causes a lot of clipping for that cube. Fixed by request of cybercat5555.