### PR TITLE
Removed getMoonPhase() check from Moonbell

### DIFF
--- a/src/main/java/com/bewitchment/common/block/natural/plants/BlockMoonbell.java
+++ b/src/main/java/com/bewitchment/common/block/natural/plants/BlockMoonbell.java
@@ -87,7 +87,7 @@ public class BlockMoonbell extends BlockModFlower implements IInfusionStabiliser
 
 	@Override
 	public void updateTick(World world, BlockPos pos, IBlockState state, Random r) {
-		if (!state.getValue(PLACED) && (world.isDaytime() || world.getMoonPhase() != 4)) {
+		if (!state.getValue(PLACED) && (world.isDaytime() /*|| world.getMoonPhase() != 4)*/) {
 			world.setBlockToAir(pos);
 			for (int i = 0; i < 7; i++) {
 				world.spawnParticle(EnumParticleTypes.FIREWORKS_SPARK, pos.getX() + r.nextDouble(), pos.getY() + r.nextDouble(), pos.getZ() + r.nextDouble(), r.nextGaussian() * 0.01, r.nextDouble() * 0.01, r.nextGaussian() * 0.01);


### PR DESCRIPTION
This is a temporary fix, until we can find a better way.