### PR TITLE
fixed solar glory ritual init

### DIFF
--- a/src/main/java/com/bewitchment/common/content/ritual/ModRituals.java
+++ b/src/main/java/com/bewitchment/common/content/ritual/ModRituals.java
@@ -50,7 +50,7 @@ public class ModRituals {
 				0 //Cost per tick
 		);
 
-		day = new RitualHighMoon(
+		day = new RitualSolarGlory(
 				rl("solar_glory"), //Reg name
 				of( //Recipe
 						LibIngredients.goldIngot,

--- a/src/main/java/com/bewitchment/common/content/ritual/rituals/RitualSolarGlory.java
+++ b/src/main/java/com/bewitchment/common/content/ritual/rituals/RitualSolarGlory.java
@@ -1,10 +1,14 @@
 package com.bewitchment.common.content.ritual.rituals;
 
+import com.bewitchment.api.transformation.DefaultTransformations;
 import com.bewitchment.common.content.ritual.RitualImpl;
+import com.bewitchment.common.content.transformation.CapabilityTransformation;
+import com.bewitchment.common.potion.ModPotions;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.potion.PotionEffect;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
@@ -21,7 +25,13 @@ public class RitualSolarGlory extends RitualImpl {
 
 	@Override
 	public void onFinish(EntityPlayer player, TileEntity tile, World world, BlockPos pos, NBTTagCompound tag, BlockPos effectivePosition, int covenSize) {
-		if (!world.isRemote) world.setWorldTime(6000);
+		if (!world.isRemote) {
+			world.playerEntities.stream()
+					.filter(p -> p.getCapability(CapabilityTransformation.CAPABILITY, null).getType() == DefaultTransformations.VAMPIRE)
+					.filter(p -> p != player)
+					.forEach(p -> p.addPotionEffect(new PotionEffect(ModPotions.sun_ward, 20 * 60 * 5)));
+			world.setWorldTime(6000);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/bewitchment/common/content/ritual/rituals/RitualSolarGlory.java
+++ b/src/main/java/com/bewitchment/common/content/ritual/rituals/RitualSolarGlory.java
@@ -27,16 +27,17 @@ public class RitualSolarGlory extends RitualImpl {
 	public void onFinish(EntityPlayer player, TileEntity tile, World world, BlockPos pos, NBTTagCompound tag, BlockPos effectivePosition, int covenSize) {
 		if (!world.isRemote) {
 			world.playerEntities.stream()
-					.filter(p -> p.getCapability(CapabilityTransformation.CAPABILITY, null).getType() == DefaultTransformations.VAMPIRE)
-					.filter(p -> p != player)
-					.forEach(p -> p.addPotionEffect(new PotionEffect(ModPotions.sun_ward, 20 * 60 * 5)));
+					.filter(p -> p.getCapability(CapabilityTransformation.CAPABILITY, null)!=null)
+					.filter(p -> p.getCapability(CapabilityTransformation.CAPABILITY, null).getType()== DefaultTransformations.VAMPIRE)
+					.filter(p -> p!=player)
+					.forEach(p -> p.addPotionEffect(new PotionEffect(ModPotions.sun_ward, 30*20)));
 			world.setWorldTime(6000);
 		}
 	}
 
 	@Override
 	public boolean isValid(EntityPlayer player, World world, BlockPos pos, List<ItemStack> recipe, BlockPos effectivePosition, int covenSize) {
-		return !world.isDaytime();
+		return !world.isDaytime() && player.getCapability(CapabilityTransformation.CAPABILITY, null).getType() != DefaultTransformations.VAMPIRE;
 	}
 
 	@Override

--- a/src/main/java/com/bewitchment/common/content/ritual/rituals/RitualSolarGlory.java
+++ b/src/main/java/com/bewitchment/common/content/ritual/rituals/RitualSolarGlory.java
@@ -27,9 +27,7 @@ public class RitualSolarGlory extends RitualImpl {
 	public void onFinish(EntityPlayer player, TileEntity tile, World world, BlockPos pos, NBTTagCompound tag, BlockPos effectivePosition, int covenSize) {
 		if (!world.isRemote) {
 			world.playerEntities.stream()
-					.filter(p -> p.getCapability(CapabilityTransformation.CAPABILITY, null)!=null)
 					.filter(p -> p.getCapability(CapabilityTransformation.CAPABILITY, null).getType()== DefaultTransformations.VAMPIRE)
-					.filter(p -> p!=player)
 					.forEach(p -> p.addPotionEffect(new PotionEffect(ModPotions.sun_ward, 30*20)));
 			world.setWorldTime(6000);
 		}


### PR DESCRIPTION
The solar glory ritual was being created as an instance of RitualHighMoon, so I changed it to the correct class. Fixes #274 