### PR TITLE
Fix/relative time change ritual

### DIFF
--- a/src/main/java/com/bewitchment/common/content/ritual/rituals/RitualHighMoon.java
+++ b/src/main/java/com/bewitchment/common/content/ritual/rituals/RitualHighMoon.java
@@ -21,7 +21,9 @@ public class RitualHighMoon extends RitualImpl {
 
 	@Override
 	public void onFinish(EntityPlayer player, TileEntity tile, World world, BlockPos pos, NBTTagCompound tag, BlockPos effectivePosition, int covenSize) {
-		if (!world.isRemote) world.setWorldTime(17600);
+		if (!world.isRemote)
+			world.setWorldTime(world.getWorldTime() + ((24000 + 17600) - (world.getWorldTime() % 24000)) % 24000);
+			//world.setWorldTime(17600);
 	}
 
 	@Override

--- a/src/main/java/com/bewitchment/common/content/ritual/rituals/RitualHighMoon.java
+++ b/src/main/java/com/bewitchment/common/content/ritual/rituals/RitualHighMoon.java
@@ -23,7 +23,6 @@ public class RitualHighMoon extends RitualImpl {
 	public void onFinish(EntityPlayer player, TileEntity tile, World world, BlockPos pos, NBTTagCompound tag, BlockPos effectivePosition, int covenSize) {
 		if (!world.isRemote)
 			world.setWorldTime(world.getWorldTime() + ((24000 + 17600) - (world.getWorldTime() % 24000)) % 24000);
-			//world.setWorldTime(17600);
 	}
 
 	@Override

--- a/src/main/java/com/bewitchment/common/content/ritual/rituals/RitualSolarGlory.java
+++ b/src/main/java/com/bewitchment/common/content/ritual/rituals/RitualSolarGlory.java
@@ -30,7 +30,6 @@ public class RitualSolarGlory extends RitualImpl {
 					.filter(p -> p.getCapability(CapabilityTransformation.CAPABILITY, null).getType() == DefaultTransformations.VAMPIRE)
 					.forEach(p -> p.addPotionEffect(new PotionEffect(ModPotions.sun_ward, 30 * 20)));
 			world.setWorldTime(world.getWorldTime() + ((24000 + 6000) - (world.getWorldTime() % 24000)) % 24000);
-			//world.setWorldTime(6000);
 		}
 	}
 

--- a/src/main/java/com/bewitchment/common/content/ritual/rituals/RitualSolarGlory.java
+++ b/src/main/java/com/bewitchment/common/content/ritual/rituals/RitualSolarGlory.java
@@ -29,7 +29,8 @@ public class RitualSolarGlory extends RitualImpl {
 			world.playerEntities.stream()
 					.filter(p -> p.getCapability(CapabilityTransformation.CAPABILITY, null).getType() == DefaultTransformations.VAMPIRE)
 					.forEach(p -> p.addPotionEffect(new PotionEffect(ModPotions.sun_ward, 30 * 20)));
-			world.setWorldTime(6000);
+			world.setWorldTime(world.getWorldTime() + ((24000 + 6000) - (world.getWorldTime() % 24000)) % 24000);
+			//world.setWorldTime(6000);
 		}
 	}
 


### PR DESCRIPTION
Currently, the rituals just set the current time to either 6000 (noon) or 17600 (20 seconds before midnight). However, this also sets the world back to day 0. Moon cycles and other events, such as Astral Sorcery constellation availability, depend on the total time. Changing the ritual to advance to the next noon or midnight increases overall compatibility.