### PR TITLE
Do not register Moonbell biomes in parallel, fixes #313

### DIFF
--- a/src/main/java/com/bewitchment/common/Bewitchment.java
+++ b/src/main/java/com/bewitchment/common/Bewitchment.java
@@ -203,7 +203,7 @@ public class Bewitchment {
 	@SuppressWarnings("deprecation")
 	@EventHandler
 	public void postInit(FMLPostInitializationEvent evt) {
-		BiomeDictionary.getBiomes(BiomeDictionary.Type.FOREST).parallelStream().filter(b -> BiomeDictionary.hasType(b, BiomeDictionary.Type.DENSE)).forEach(b -> {
+		BiomeDictionary.getBiomes(BiomeDictionary.Type.FOREST).stream().filter(b -> BiomeDictionary.hasType(b, BiomeDictionary.Type.DENSE)).forEach(b -> {
 			BlockMoonbell.addValidMoonbellBiome(b);
 		});
 		if (entityConfig.hasChanged()) {


### PR DESCRIPTION
`BlockMoonbell#addValidMoonbellBiome(Biome)` would sometimes cause a crash on startup because multiple threads were modifying the list at the same time.

The fix here is simple and merely changes the `parallelStream()` call for a regular `stream()` call. There is no advantage to using a parallel stream here as the time spent to add an item to a list is extremely tiny. In fact, the overhead of queueing biome registrations in parallel far outweighs the amount of time that can be saved.