### PR TITLE
Item transfers into the witches' oven now sort into the correct slots

### DIFF
--- a/src/main/java/com/bewitchment/common/block/tile/container/ContainerWitchesOven.java
+++ b/src/main/java/com/bewitchment/common/block/tile/container/ContainerWitchesOven.java
@@ -3,6 +3,7 @@ package com.bewitchment.common.block.tile.container;
 import com.bewitchment.common.block.tile.container.util.ModContainer;
 import com.bewitchment.common.block.tile.container.util.ModSlot;
 import com.bewitchment.common.block.tile.entity.TileEntityWitchesOven;
+
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IContainerListener;
 import net.minecraft.util.EnumFacing;
@@ -21,11 +22,11 @@ public class ContainerWitchesOven extends ModContainer {
 		IItemHandler up = tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.UP);
 		IItemHandler down = tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.DOWN);
 		int ui = 0, di = 0;
-		addSlotToContainer(new ModSlot(up, ui++, 44, 55));
-		addSlotToContainer(new ModSlot(up, ui++, 80, 55));
-		addSlotToContainer(new ModSlot(up, ui++, 44, 19));
-		addSlotToContainer(new ModSlot(down, di++, 116, 19));
-		addSlotToContainer(new ModSlot(down, di++, 116, 55));
+		addSlotToContainer(new ModSlot(up, ui++, 44, 55)); //fuel
+		addSlotToContainer(new ModSlot(up, ui++, 80, 55)); //jars
+		addSlotToContainer(new ModSlot(up, ui++, 44, 19)); //input
+		addSlotToContainer(new ModSlot(down, di++, 116, 19)); //output
+		addSlotToContainer(new ModSlot(down, di++, 116, 55)); //fume output
 		addPlayerSlots(inventory);
 	}
 	

--- a/src/main/java/com/bewitchment/common/block/tile/entity/TileEntityWitchesOven.java
+++ b/src/main/java/com/bewitchment/common/block/tile/entity/TileEntityWitchesOven.java
@@ -5,6 +5,7 @@ import com.bewitchment.api.registry.OvenRecipe;
 import com.bewitchment.common.block.BlockWitchesOven;
 import com.bewitchment.common.block.tile.entity.util.ModTileEntity;
 import com.bewitchment.registry.ModObjects;
+
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
@@ -32,9 +33,17 @@ public class TileEntityWitchesOven extends ModTileEntity implements ITickable, I
 	public int burnTime, fuelBurnTime, progress;
 	private OvenRecipe recipe;
 	private final ItemStackHandler inventory_up = new ItemStackHandler(3) {
+		
 		@Override
-		public boolean isItemValid(int index, ItemStack stack) {
-			return index == 0 ? TileEntityFurnace.isItemFuel(stack) : index != 1 || stack.getItem() == ModObjects.empty_jar;
+		public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
+			return this.isItemValid(slot, stack) ? super.insertItem(slot, stack, simulate) : stack;
+		}
+		
+		@Override
+		public boolean isItemValid(int slot, ItemStack stack) {
+			return ((slot == 0 ? TileEntityFurnace.isItemFuel(stack) : slot == 2) 
+					|| (slot == 1 ? stack.getItem() == ModObjects.empty_jar : slot == 2))  && 
+					(getStackInSlot(slot).isEmpty() || Util.canMerge(stack, getStackInSlot(slot)));
 		}
 		
 		@Override

--- a/src/main/java/com/bewitchment/common/integration/dynamictrees/BiomeDataBasePopulator.java
+++ b/src/main/java/com/bewitchment/common/integration/dynamictrees/BiomeDataBasePopulator.java
@@ -39,11 +39,11 @@ public class BiomeDataBasePopulator implements IBiomeDataBasePopulator {
 		//BiomePropertySelectors.RandomSpeciesSelector bothSelector = oliveWeight != 0 && ironWeight != 0 ? (new BiomePropertySelectors.RandomSpeciesSelector()).add(1000 - (oliveWeight + ironWeight)).add(olive, oliveWeight).add(ironwood, ironWeight) : null;
 		
 		Biome.REGISTRY.forEach(b -> {
-			boolean cypressSplice = cypressSelector != null && (BiomeDictionary.hasType(b, BiomeDictionary.Type.FOREST) && (BiomeDictionary.hasType(b, BiomeDictionary.Type.COLD) || BiomeDictionary.hasType(b, BiomeDictionary.Type.SPOOKY)));
-			boolean elderSplice = elderSelector != null && BiomeDictionary.hasType(b, BiomeDictionary.Type.FOREST) && !BiomeDictionary.hasType(b, BiomeDictionary.Type.COLD);
-			boolean juniperSplice = juniperSelector != null && (BiomeDictionary.hasType(b, BiomeDictionary.Type.SAVANNA) || BiomeDictionary.hasType(b, BiomeDictionary.Type.MAGICAL));
+			boolean cypressSplice = cypressSelector != null && (BiomeDictionary.hasType((Biome) b, BiomeDictionary.Type.FOREST) && (BiomeDictionary.hasType((Biome) b, BiomeDictionary.Type.COLD) || BiomeDictionary.hasType((Biome) b, BiomeDictionary.Type.SPOOKY)));
+			boolean elderSplice = elderSelector != null && BiomeDictionary.hasType((Biome) b, BiomeDictionary.Type.FOREST) && !BiomeDictionary.hasType((Biome) b, BiomeDictionary.Type.COLD);
+			boolean juniperSplice = juniperSelector != null && (BiomeDictionary.hasType((Biome) b, BiomeDictionary.Type.SAVANNA) || BiomeDictionary.hasType((Biome) b, BiomeDictionary.Type.MAGICAL));
 			if (cypressSplice || elderSplice || juniperSplice) {
-				dbase.setSpeciesSelector(b, cypressSplice ? cypressSelector : elderSplice ? elderSelector : juniperSelector, BiomeDataBase.Operation.SPLICE_BEFORE);
+				dbase.setSpeciesSelector((Biome) b, cypressSplice ? cypressSelector : elderSplice ? elderSelector : juniperSelector, BiomeDataBase.Operation.SPLICE_BEFORE);
 			}
 		});
 	}


### PR DESCRIPTION
The items now go into the first available slot which is compatible (jars were able to go into the fuel slot with a hopper and fuel items into the jars slot).