### PR TITLE
optimization fixes relating to #633

### DIFF
--- a/src/main/java/com/bewitchment/api/BewitchmentAPI.java
+++ b/src/main/java/com/bewitchment/api/BewitchmentAPI.java
@@ -50,6 +50,9 @@ public class BewitchmentAPI {
 	public static BiomeDictionary.Type IMMUTABLE;
 	private static BewitchmentAPI INSTANCE;
 
+	public static final Set<String> COLD_IRON_WEAKNESS = new HashSet<>(Arrays.asList("EntityPixie", "EntityHirschgeist", "EntityPech", "EntityFairy", "EntityGhost", "Succubus", "Dullahan"));
+	public static final Set<String> SILVER_WEAKNESS = new HashSet<>(Arrays.asList("Dracula", "TurnedVillager", "Wendigo"));
+
 	/**
 	 * @param entity the entity to check
 	 * @return true if the entity is a witch, false otherwise
@@ -71,7 +74,7 @@ public class BewitchmentAPI {
 	 * @return false always, vampires are not currently in the mod
 	 */
 	public static boolean isVampire(EntityLivingBase entity) {
-		return false;
+		return entity.getClass().getName().contains("Vampire");
 	}
 
 	/**
@@ -79,7 +82,7 @@ public class BewitchmentAPI {
 	 * @return false always, werewolves are not currently in the mod
 	 */
 	public static boolean isWerewolf(EntityLivingBase entity) {
-		return false;
+		return entity.getClass().getName().contains("Werewolf");
 	}
 
 	/**
@@ -210,7 +213,14 @@ public class BewitchmentAPI {
 
 	public static float getSilverWeakness(EntityLivingBase entity) {
 		float fin = 1;
-		if (isVampire(entity) || isWerewolf(entity) || entity.isEntityUndead() || entity.getClass().getName().endsWith("Vampire") || entity.getClass().getName().endsWith("EntityVampireBase") || entity.getClass().getName().endsWith("EntityVampireBaron") || entity.getClass().getName().endsWith("EntityVampireBase") || entity.getClass().getName().endsWith("EntityVampireFactionVillager") || entity.getClass().getName().endsWith("EntityVampire") || entity.getClass().getName().endsWith("EntityBasicVampire") || entity.getClass().getName().endsWith("EntityAdvancedVampire") || entity.getClass().getName().endsWith("EntityDraculaHalloween") || entity.getClass().getName().endsWith("EntityWerewolf") || entity.getClass().getName().endsWith("Werewolf") || entity.getClass().getName().endsWith("EntityTurnedVillager") || entity.getClass().getName().endsWith("EntityWendigo")) {
+		boolean flag = false;
+		for (String name : COLD_IRON_WEAKNESS) {
+			if (entity.getClass().getName().contains(name)) {
+				flag = true;
+				break;
+			}
+		}
+		if (entity.isEntityUndead() || flag || isVampire(entity) || isWerewolf(entity)) {
 			fin = 1.5f;
 			if (entity instanceof EntityPlayer) fin *= 1.5f;
 		}
@@ -219,7 +229,14 @@ public class BewitchmentAPI {
 
 	public static float getColdIronWeakness(EntityLivingBase entity) {
 		float fin = 1;
-		if (entity.getCreatureAttribute() == DEMON || entity.getCreatureAttribute() == SPIRIT || entity.getCreatureAttribute() == FAE || entity instanceof EntityBlaze || entity instanceof EntityVex || entity instanceof EntityGhast || entity instanceof EntityEnderman || entity.getClass().getName().endsWith("EntityPixie") || entity.getClass().getName().endsWith("EntityHirschgeist") || entity.getClass().getName().endsWith("EntityPech") || entity.getClass().getName().endsWith("EntityFairy") || entity.getClass().getName().endsWith("EntityGhost") || entity.getClass().getName().contains("Succubus") || entity.getClass().getName().contains("Dullahan")) {
+		boolean flag = false;
+		for (String name : COLD_IRON_WEAKNESS) {
+			if (entity.getClass().getName().contains(name)) {
+				flag = true;
+				break;
+			}
+		}
+		if (flag || entity.getCreatureAttribute() == DEMON || entity.getCreatureAttribute() == SPIRIT || entity.getCreatureAttribute() == FAE || entity instanceof EntityBlaze || entity instanceof EntityVex || entity instanceof EntityGhast || entity instanceof EntityEnderman) {
 			fin = 1.5f;
 			if (entity instanceof EntityPlayer) fin *= 1.5f;
 		}

--- a/src/main/java/com/bewitchment/common/block/BlockFrostfire.java
+++ b/src/main/java/com/bewitchment/common/block/BlockFrostfire.java
@@ -71,7 +71,7 @@ public class BlockFrostfire extends ModBlockContainer {
 
 	@Override
 	public void onEntityCollision(World world, BlockPos pos, IBlockState state, Entity entity) {
-		if (!world.isRemote && entity instanceof EntityLivingBase && BewitchmentAPI.getColdIronWeakness((EntityLivingBase) entity) > 1)
+		if (!world.isRemote && entity instanceof EntityLivingBase && BewitchmentAPI.getColdIronWeakness((EntityLivingBase) entity) > 1f)
 			entity.attackEntityFrom(DamageSource.MAGIC, 2);
 	}
 

--- a/src/main/java/com/bewitchment/common/block/BlockPurifyingEarth.java
+++ b/src/main/java/com/bewitchment/common/block/BlockPurifyingEarth.java
@@ -33,7 +33,7 @@ public class BlockPurifyingEarth extends ModBlock {
 		if (entity instanceof EntityLivingBase) {
 			EntityLivingBase living = (EntityLivingBase) entity;
 			EnumCreatureAttribute att = living.getCreatureAttribute();
-			if ((BewitchmentAPI.getSilverWeakness(living) > 1 && !BewitchmentAPI.isWerewolf(living)) || BewitchmentAPI.getColdIronWeakness(living) > 1 && !living.isBurning())
+			if ((BewitchmentAPI.getSilverWeakness(living) > 1f && !BewitchmentAPI.isWerewolf(living)) || BewitchmentAPI.getColdIronWeakness(living) > 1f && !living.isBurning())
 				living.setFire(25);
 		}
 	}

--- a/src/main/java/com/bewitchment/common/block/BlockSaltBarrier.java
+++ b/src/main/java/com/bewitchment/common/block/BlockSaltBarrier.java
@@ -39,7 +39,7 @@ public class BlockSaltBarrier extends BlockRedstoneWire {
 	@Override
 	public void addCollisionBoxToList(IBlockState state, World world, BlockPos pos, AxisAlignedBB box, List<AxisAlignedBB> boxes, Entity entity, boolean wut) {
 		if (entity instanceof EntityLivingBase) {
-			if ((BewitchmentAPI.getSilverWeakness((EntityLivingBase) entity) > 1 && !BewitchmentAPI.isWerewolf((EntityLivingBase) entity)) || BewitchmentAPI.getColdIronWeakness((EntityLivingBase) entity) > 1)
+			if ((BewitchmentAPI.getSilverWeakness((EntityLivingBase) entity) > 1f && !BewitchmentAPI.isWerewolf((EntityLivingBase) entity)) || BewitchmentAPI.getColdIronWeakness((EntityLivingBase) entity) > 1f)
 				addCollisionBoxToList(pos, box, boxes, WALL);
 		}
 		if (entity instanceof EntitySlime) {

--- a/src/main/java/com/bewitchment/common/block/tile/entity/TileEntityWitchesAltar.java
+++ b/src/main/java/com/bewitchment/common/block/tile/entity/TileEntityWitchesAltar.java
@@ -35,7 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
-@SuppressWarnings({"ConstantConditions", "WeakerAccess", "NullableProblems", "StatementWithEmptyBody"})
+@SuppressWarnings({"ConstantConditions", "WeakerAccess", "NullableProblems"})
 public class TileEntityWitchesAltar extends ModTileEntity implements ITickable {
 	public final MagicPower magicPower = MagicPower.CAPABILITY.getDefaultInstance();
 	private final Map<IBlockState, Integer> map = new HashMap<>();
@@ -96,7 +96,7 @@ public class TileEntityWitchesAltar extends ModTileEntity implements ITickable {
 
 	@Override
 	public void update() {
-		if (!world.isRemote) {
+		if (!world.isRemote && world.isBlockLoaded(this.pos)) {
 			if (world.getTotalWorldTime() % 100 == 0) {
 				for (EntityPlayer player : world.getEntitiesWithinAABB(EntityPlayer.class, new AxisAlignedBB(pos).grow(25))) {
 					for (int i = 0; i < player.inventory.getSizeInventory(); i++) {
@@ -208,9 +208,7 @@ public class TileEntityWitchesAltar extends ModTileEntity implements ITickable {
 	}
 
 	protected boolean isNatural(IBlockState state) {
-		if (Loader.isModLoaded("dynamictrees")) {
-		}
-		return (!(state.getBlock() instanceof BlockGrass)) && (state.getBlock() instanceof IGrowable || state.getBlock() instanceof IPlantable || state.getBlock() instanceof BlockMelon || state.getBlock() instanceof BlockPumpkin || state.getBlock() instanceof BlockLeaves || (state.getBlock() instanceof BlockRotatedPillar && state.getMaterial() == Material.WOOD));
+		return ((state.getBlock() instanceof IGrowable || state.getBlock() instanceof IPlantable || state.getBlock() instanceof BlockMelon || state.getBlock() instanceof BlockPumpkin || state.getBlock() instanceof BlockLeaves || (state.getBlock() instanceof BlockRotatedPillar && state.getMaterial() == Material.WOOD)) && !(state.getBlock() instanceof BlockGrass));
 	}
 
 	protected boolean isStatue(IBlockState state) {

--- a/src/main/java/com/bewitchment/common/block/tile/entity/TileEntityWitchesOven.java
+++ b/src/main/java/com/bewitchment/common/block/tile/entity/TileEntityWitchesOven.java
@@ -88,17 +88,28 @@ public class TileEntityWitchesOven extends ModTileEntity implements ITickable, I
 	@Override
 	public void update() {
 		if (!world.isRemote) {
-			if (burning && burnTime < 1)
+			// set texture to burning if burning
+			if (burning && burnTime < 1) {
 				burning = world.setBlockState(pos, world.getBlockState(pos).withProperty(BlockWitchesOven.LIT, false));
-			if (burnTime > 0) burnTime--;
-			else {
+			}
+			// reduce burn time
+			if (burnTime > 0) {
+				burnTime--;
+			} else {
+				// if no fuel time remaining, start decrementing progress
 				if (progress > 0) {
 					progress -= 2;
 					if (progress < 0) progress = 0;
 				}
 			}
-			if ((recipe == null || !recipe.isValid(inventory_up, inventory_down)) && !isFurnaceRecipe()) progress = 0;
-			else {
+			// if input empty, skip recipe checks
+			if (inventory_up.getStackInSlot(2).isEmpty()) {
+				progress = 0;
+				return;
+			}
+			if ((recipe == null || !recipe.isValid(inventory_up, inventory_down)) && !isFurnaceRecipe()) {
+				progress = 0;
+			} else {
 				if (burnTime < 1) {
 					int time = TileEntityFurnace.getItemBurnTime(inventory_up.getStackInSlot(0));
 					if (time > 0) burnFuel(time, true);
@@ -128,7 +139,7 @@ public class TileEntityWitchesOven extends ModTileEntity implements ITickable, I
 	@Override
 	@Optional.Method(modid = "botania")
 	public boolean canSmelt() {
-		return (recipe != null && recipe.isValid(inventory_up, inventory_down)) || isFurnaceRecipe();
+		return !inventory_up.getStackInSlot(2).isEmpty() && ((recipe != null && recipe.isValid(inventory_up, inventory_down)) || isFurnaceRecipe());
 	}
 
 	@Override

--- a/src/main/java/com/bewitchment/common/entity/misc/EntitySilverArrow.java
+++ b/src/main/java/com/bewitchment/common/entity/misc/EntitySilverArrow.java
@@ -33,7 +33,7 @@ public class EntitySilverArrow extends EntityArrow {
 	@Override
 	protected void arrowHit(EntityLivingBase living) {
 		float weakness = isColdIron() ? BewitchmentAPI.getColdIronWeakness(living) : BewitchmentAPI.getSilverWeakness(living);
-		if (weakness > 1) living.attackEntityFrom(DamageSource.MAGIC, BewitchmentAPI.getSilverWeakness(living));
+		if (weakness > 1f) living.attackEntityFrom(DamageSource.MAGIC, BewitchmentAPI.getSilverWeakness(living));
 		super.arrowHit(living);
 	}
 

--- a/src/main/java/com/bewitchment/common/handler/MaterialHandler.java
+++ b/src/main/java/com/bewitchment/common/handler/MaterialHandler.java
@@ -28,18 +28,18 @@ public class MaterialHandler {
 	@SubscribeEvent
 	public void livingUpdate(LivingEvent.LivingUpdateEvent event) {
 		EntityLivingBase entity = event.getEntityLiving();
-		if (!entity.world.isRemote) {
-			if (BewitchmentAPI.getSilverWeakness(entity) > 1) {
+		if (!entity.world.isRemote && entity.ticksExisted % 20 == 0) {
+			if (BewitchmentAPI.getSilverWeakness(entity) > 1f) {
 				int armor = 0;
 				for (ItemStack stack : entity.getArmorInventoryList())
 					if (SILVER_ARMOR.contains(stack.getItem())) armor++;
-				if (armor > 0 && entity.ticksExisted % 20 == 0) entity.attackEntityFrom(DamageSource.MAGIC, armor);
+				if (armor > 0) entity.attackEntityFrom(DamageSource.MAGIC, armor);
 			}
-			if (BewitchmentAPI.getColdIronWeakness(entity) > 1) {
+			if (BewitchmentAPI.getColdIronWeakness(entity) > 1f) {
 				int armor = 0;
 				for (ItemStack stack : entity.getArmorInventoryList())
 					if (COLD_IRON_ARMOR.contains(stack.getItem())) armor++;
-				if (armor > 0 && entity.ticksExisted % 20 == 0) entity.attackEntityFrom(DamageSource.MAGIC, armor);
+				if (armor > 0) entity.attackEntityFrom(DamageSource.MAGIC, armor);
 			}
 		}
 	}
@@ -52,10 +52,10 @@ public class MaterialHandler {
 			if (source instanceof EntityLivingBase) {
 				{ //silver
 					float weakness = BewitchmentAPI.getSilverWeakness(entity);
-					if (weakness > 1 && SILVER_TOOLS.contains(((EntityLivingBase) source).getHeldItemMainhand().getItem()))
+					if (weakness > 1f && SILVER_TOOLS.contains(((EntityLivingBase) source).getHeldItemMainhand().getItem()))
 						event.setAmount(event.getAmount() * weakness);
 					weakness = BewitchmentAPI.getSilverWeakness((EntityLivingBase) source);
-					if (weakness > 1) {
+					if (weakness > 1f) {
 						int armor = 0;
 						for (ItemStack stack : entity.getArmorInventoryList())
 							if (SILVER_ARMOR.contains(stack.getItem())) armor++;
@@ -67,10 +67,10 @@ public class MaterialHandler {
 				}
 				{ //cold iron
 					float weakness = BewitchmentAPI.getColdIronWeakness(entity);
-					if (weakness > 1 && COLD_IRON_TOOLS.contains(((EntityLivingBase) source).getHeldItemMainhand().getItem()))
+					if (weakness > 1f && COLD_IRON_TOOLS.contains(((EntityLivingBase) source).getHeldItemMainhand().getItem()))
 						event.setAmount(event.getAmount() * weakness);
 					weakness = BewitchmentAPI.getColdIronWeakness((EntityLivingBase) source);
-					if (weakness > 1) {
+					if (weakness > 1f) {
 						int armor = 0;
 						for (ItemStack stack : entity.getArmorInventoryList())
 							if (COLD_IRON_ARMOR.contains(stack.getItem())) armor++;

--- a/src/main/java/com/bewitchment/common/integration/thaumcraft/ThaumcraftCompat.java
+++ b/src/main/java/com/bewitchment/common/integration/thaumcraft/ThaumcraftCompat.java
@@ -145,10 +145,10 @@ public class ThaumcraftCompat implements IConditionFactory {
 			Entity source = event.getSource().getImmediateSource();
 			if (source instanceof EntityLivingBase) {
 				float weakness = BewitchmentAPI.getColdIronWeakness(entity);
-				if (weakness > 1 && isColdIronGolem((EntityLivingBase) source))
+				if (weakness > 1f && isColdIronGolem((EntityLivingBase) source))
 					event.setAmount(event.getAmount() * weakness * 2);
 				weakness = BewitchmentAPI.getColdIronWeakness((EntityLivingBase) source);
-				if (weakness > 1 && isColdIronGolem(entity)) {
+				if (weakness > 1f && isColdIronGolem(entity)) {
 					event.setAmount(event.getAmount() * 0.4F);
 					source.attackEntityFrom(DamageSource.causeThornsDamage(entity), 4);
 				}

--- a/src/main/java/com/bewitchment/common/item/equipment/baubles/ItemHorseshoe.java
+++ b/src/main/java/com/bewitchment/common/item/equipment/baubles/ItemHorseshoe.java
@@ -40,7 +40,7 @@ public class ItemHorseshoe extends ModItemBauble {
 
 	@SubscribeEvent
 	public void onHurt(LivingHurtEvent event) {
-		if (Util.hasBauble(event.getEntityLiving(), this) && (event.getSource().getTrueSource() instanceof EntityLivingBase && BewitchmentAPI.getColdIronWeakness((EntityLivingBase) event.getSource().getTrueSource()) > 1) && event.getEntityLiving() instanceof EntityPlayer && MagicPower.attemptDrain(null, (EntityPlayer) event.getEntityLiving(), 20))
+		if (Util.hasBauble(event.getEntityLiving(), this) && (event.getSource().getTrueSource() instanceof EntityLivingBase && BewitchmentAPI.getColdIronWeakness((EntityLivingBase) event.getSource().getTrueSource()) > 1f) && event.getEntityLiving() instanceof EntityPlayer && MagicPower.attemptDrain(null, (EntityPlayer) event.getEntityLiving(), 20))
 			event.setAmount(event.getAmount() * 0.9f);
 	}
 }


### PR DESCRIPTION
## Some Optimizations After Reading #633 
- Ghosts no longer scan blocks in separate loops, functionality maintains but less blocks are scanned vertically.
- Silver/Cold Iron weakness uses consts now
- Altar checking for dynamic trees is doing nothing, removed check.
- Move around isNatural() a little bit
- Witches oven no longer checks for recipes if input slot is empty
- Cauldron no longer creates excess AABB Objects.
- Cauldron sends particle updates only to entities 16 blocks around the target
- Added isBlockLoaded check before altar updates, unsure if it helps.

## Concessions
Despite my reservations on working on this piece of crap again, i hate seeing bad code being sent over to players. Here's some fixes thanks to @LemADEC pointing them out.