### PR TITLE
Adding a null check in SyncExtendedPlayer to prevent crashing.

### DIFF
--- a/src/main/java/com/bewitchment/api/message/SyncExtendedPlayer.java
+++ b/src/main/java/com/bewitchment/api/message/SyncExtendedPlayer.java
@@ -34,8 +34,12 @@ public class SyncExtendedPlayer implements IMessage {
 	public static class Handler implements IMessageHandler<SyncExtendedPlayer, IMessage> {
 		@Override
 		public IMessage onMessage(SyncExtendedPlayer message, MessageContext ctx) {
-			if (ctx.side.isClient())
-				Minecraft.getMinecraft().addScheduledTask(() -> Minecraft.getMinecraft().player.getCapability(ExtendedPlayer.CAPABILITY, null).deserializeNBT(message.tag));
+			if(message != null && ctx != null){
+				if(message.tag != null){
+					if (ctx.side.isClient())
+						Minecraft.getMinecraft().addScheduledTask(() -> Minecraft.getMinecraft().player.getCapability(ExtendedPlayer.CAPABILITY, null).deserializeNBT(message.tag));
+				}
+			}
 			return null;
 		}
 	}


### PR DESCRIPTION
Hey! We were having an issue on our server where a player had been repeatedly generating crash reports whilst exploring the world but since VanillaFix was installed it hadn't crashed the client entirely: [crash-2020-10-14_02.33.18-client.txt](https://github.com/Um-Mitternacht/Bewitchment/files/5380191/crash-2020-10-14_02.33.18-client.1.txt)

```java
java.util.concurrent.ExecutionException: java.lang.NullPointerException
Caused by: java.lang.NullPointerException
    at com.bewitchment.api.message.SyncExtendedPlayer$Handler.lambda$onMessage$0(SyncExtendedPlayer.java:38)
    at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
    at java.util.concurrent.FutureTask.run(Unknown Source)
    at net.minecraft.util.Util.runTask(Util.java:529)
```
I wasn't too sure whether this would occur on a fresh install only with Bewitchment installed or whether it was due to a messy interaction with another mod - since this was on MC Eternal, but I thought it'd be best to put in a null check for all of the possible variables in the crash, just to be safe.

I hope this helps, if I notice any more issues in a public server environment that I'm able to fix, I'll be sure to send in another PR. 
Thank you!